### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,109 +1,43 @@
+termux-سودو
+يعد البرنامج النصي bash الذي يوفر sudo لـ Termux
+Termux محاكيًا طارئًا وبيئة Linux لنظام Android
 
-#!/data/data/com.termux/files/usr/bin/bash
+ملحوظة
 
-#set colored=true to turn on colored error messages
-#set colored=false to turn off colored error messages
-colored=true
+استضافت termux-sudo في الأصل على جيثب.
+نظرًا لحقيقة حذف Termux sudo من Github ، فقد قررت تحميله لمتطلبات الاستخدام العام
 
-#red=1 green=2 yellow=3
-color() {
-	if [ $colored == "true" ]; then
-		echo "$(tput setaf $1)${*:2}$(tput sgr0)"
-	else
-		echo "${*:2}"
-	fi
-}
+الهاتف الجذر مع سو
+سودو ثنائي لن تعمل دون سو
 
-show_usage() {
-	echo -e "\n`color 3 Usage:`\n"
-	echo 'sudo su [-]'
-	echo -e "  `color 2 Drop to root shell`\n"
-	echo 'sudo <command> [<args>]'
-	echo -e "  `color 2 Run command as root with optional arguments`\n"
-	exit
-}
+تثبيت sudo
 
-SYSBIN=/system/bin
-SYSXBIN=/system/xbin
-BB=$SYSXBIN/busybox
-PRE=/data/data/com.termux/files
-ROOT_HOME=$PRE/home/.suroot
-BINPRE=$PRE/usr/bin
-LDLP="export LD_LIBRARY_PATH=$PRE/usr/lib"
-CMDLINE="PATH=$PATH:$SYSXBIN:$SYSBIN;$LDLP;HOME=$ROOT_HOME;cd $PWD"
+استنساخ termux-sudo أو قم بتنزيله على الهاتف واستخرجه
+فتح Termux
+تثبيت التبعية اللازمة ل sudo: pkg install ncurses-utils
+التغيير إلى دليل الاستنساخ أو الاستخراج
+تنفيذ الأوامر التالية لوضع sudo في الدليل الصحيح مع الأذونات المناسبة والملكية
+cat sudo > /data/data/com.termux/files/usr/bin/sudo
+chmod 700 /data/data/com.termux/files/usr/bin/sudo
+المميزات
 
-if [ -x /magisk/.core/bin/su ]; then
-	SU=/magisk/.core/bin/su
-elif [ -x /sbin/su ]; then
-	SU=/sbin/su
-elif [ -x $SYSXBIN/su ]; then
-	SU=$SYSXBIN/su
-elif [ -x /su/bin/su ]; then
-	SU=/su/bin/su
-else
-	echo -e "\n`color 1 su` executable not found"
-	echo -e "`color 1 sudo` requires `color 1 su`\n"
-	exit
-fi
+إعداد بيئتها تلقائيًا عند التشغيل لأول مرة ، ولا حاجة إلى القيام بأي شيء سوى استخدامه
+إنشاء مجلد جذر .surootفي المجلد الرئيسي Termux مع أذونات الجذر المناسبة والملكية
+يقوم بإنشاء .bashrcملف في مجلد جذر باستخدام متغيرات PATH و LD_LIBRARY_PATH مناسبة حتى تعمل جميع الثنائيات بشكل صحيح
+تم تعيين متغير Bash موجه PS1 أيضًا بحيث لا يكون لديك bash-4.4#مطالبة فقط#
+يتم إنشاء .bash_historyمجلد الجذر تلقائيًا عند إسقاطه إلى قشرة جذر بحيث يتم الاحتفاظ بمحفوظات قشرة الجذر
+يمكن استخدامها مثل sudo العادي (ولكن فقط كجذر ، لا مستخدم آخر)
+يمكن أن تنخفض إلى جذر قذيفة sudo su [-]
+يعمل في ثنائيات Termux والثنائيات الخارجية مع الوسائط الاختيارية كجذر في الدليل الحالي
+يولد الإخراج في قذيفة تستخدم حاليا
+يمكن استخدامها في البرامج النصية باش الأخرى
+[خيار] يمكن إيقاف تشغيل رسائل الخطأ الملونة وتحرير المتغير coloredفي بداية ملف sudo
+Usage:
 
-if [ ! -d $ROOT_HOME ]; then
-	if [ -x $BB ] && [ $($BB --list | grep -w mount) == "mount" ]; then
-		MOUNTEX="$BB mount"
-	elif [ -x $SYSBIN/mount ]; then
-		MOUNTEX="$SYSBIN/mount"
-	else
-		echo -e "\nCannot find `color 1 mount` executable"
-		echo -e "`color 2 Unable to setup sudo`\n"
-		exit
-	fi
-	MOUNT_RW="$MOUNTEX -o rw,remount,rw /system"
-	MOUNT_RO="$MOUNTEX -o ro,remount,ro /system"
-	if [ -x "/sbin/magisk" ]; then
-		unset LD_LIBRARY_PATH
-		$SU -c "$CMDLINE;$MOUNT_RW"
-		$SU -c "$CMDLINE;mkdir $ROOT_HOME"
-		$SU -c "$CMDLINE;chmod 700 $ROOT_HOME"
-		BASHRC="'PS1=\"# \"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
-		$SU -c "$CMDLINE;echo -e $BASHRC > $ROOT_HOME/.bashrc"
-		$SU -c "$CMDLINE;chmod 700 $ROOT_HOME/.bashrc"
-		$SU -c "$CMDLINE;$MOUNT_RO"
-	else
-		$SU -c "$MOUNT_RW"
-		$SU -c "mkdir $ROOT_HOME"
-		$SU -c "chmod 700 $ROOT_HOME"
-		BASHRC="'PS1=\"# \"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
-		$SU -c "echo -e $BASHRC > $ROOT_HOME/.bashrc"
-		$SU -c "chmod 700 $ROOT_HOME/.bashrc"
-		$SU -c "$MOUNT_RO"
-	fi
-fi
+sudo su [-]  
+  Drop to root shell
 
-ARGS=$(printf '%q ' "$@")
-
-if [ -z "$*" ]; then
-	show_usage
-elif [ $1 == "su" ]; then
-	CMDLINE="$CMDLINE;$BINPRE/bash"
-elif [ -x "$BINPRE/$1" ]; then
-	CMDLINE="$CMDLINE;$BINPRE/$ARGS"
-elif [ -x $SYSBIN/$1 ] || [ -x $SYSXBIN/$1 ] || [ -x $1 ]; then
-	CMDLINE="$CMDLINE;$ARGS"
-else
-	echo -e "\nCommand `color 1 $1` not found"
-	echo -e "`color 2 Check your spelling and try again`\n"
-fi
-
-pre_env_chk=`$SU --help|grep -e --preserve-environment`
-
-if [ -x "/sbin/magisk" ]; then
-	unset LD_LIBRARY_PATH
-fi
-
-if [ -n "$pre_env_chk" ]; then
-        $SU --preserve-environment -c "$CMDLINE"
-else
-        $SU -c "$CMDLINE"
-fi
-
-# Reset echo
-stty sane
+sudo <command> [<args>]  
+  Run command as root with optional arguments
+استلهم هذا ما يلي: https://github.com/st42/termux-sudo https://github.com/cswl/tsu
+https://gist.github.com/cswl/cd13971e644dc5ced7b2


### PR DESCRIPTION
#!/data/data/com.termux/files/usr/bin/bash

#set colored=true to turn on colored error messages
#set colored=false to turn off colored error messages
colored=true

#red=1 green=2 yellow=3
color() {
	if [ $colored == "true" ]; then
		echo "$(tput setaf $1)${*:2}$(tput sgr0)"
	else
		echo "${*:2}"
	fi
}

show_usage() {
	echo -e "\n`color 3 Usage:`\n"
	echo 'sudo su [-]'
	echo -e "  `color 2 Drop to root shell`\n"
	echo 'sudo <command> [<args>]'
	echo -e "  `color 2 Run command as root with optional arguments`\n"
	exit
}

SYSBIN=/system/bin
SYSXBIN=/system/xbin
BB=$SYSXBIN/busybox
PRE=/data/data/com.termux/files
ROOT_HOME=$PRE/home/.suroot
BINPRE=$PRE/usr/bin
LDLP="export LD_LIBRARY_PATH=$PRE/usr/lib"
CMDLINE="PATH=$PATH:$SYSXBIN:$SYSBIN;$LDLP;HOME=$ROOT_HOME;cd $PWD"

if [ -x /magisk/.core/bin/su ]; then
	SU=/magisk/.core/bin/su
elif [ -x /sbin/su ]; then
	SU=/sbin/su
elif [ -x $SYSXBIN/su ]; then
	SU=$SYSXBIN/su
elif [ -x /su/bin/su ]; then
	SU=/su/bin/su
else
	echo -e "\n`color 1 su` executable not found"
	echo -e "`color 1 sudo` requires `color 1 su`\n"
	exit
fi

if [ ! -d $ROOT_HOME ]; then
	if [ -x $BB ] && [ $($BB --list | grep -w mount) == "mount" ]; then
		MOUNTEX="$BB mount"
	elif [ -x $SYSBIN/mount ]; then
		MOUNTEX="$SYSBIN/mount"
	else
		echo -e "\nCannot find `color 1 mount` executable"
		echo -e "`color 2 Unable to setup sudo`\n"
		exit
	fi
	MOUNT_RW="$MOUNTEX -o rw,remount,rw /system"
	MOUNT_RO="$MOUNTEX -o ro,remount,ro /system"
	if [ -x "/sbin/magisk" ]; then
		unset LD_LIBRARY_PATH
		$SU -c "$CMDLINE;$MOUNT_RW"
		$SU -c "$CMDLINE;mkdir $ROOT_HOME"
		$SU -c "$CMDLINE;chmod 700 $ROOT_HOME"
		BASHRC="'PS1=\"# \"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
		$SU -c "$CMDLINE;echo -e $BASHRC > $ROOT_HOME/.bashrc"
		$SU -c "$CMDLINE;chmod 700 $ROOT_HOME/.bashrc"
		$SU -c "$CMDLINE;$MOUNT_RO"
	else
		$SU -c "$MOUNT_RW"
		$SU -c "mkdir $ROOT_HOME"
		$SU -c "chmod 700 $ROOT_HOME"
		BASHRC="'PS1=\"# \"\nexport TERM=$TERM\n$LDLP\nexport PATH=$PATH:$SYSXBIN:$SYSBIN'"
		$SU -c "echo -e $BASHRC > $ROOT_HOME/.bashrc"
		$SU -c "chmod 700 $ROOT_HOME/.bashrc"
		$SU -c "$MOUNT_RO"
	fi
fi

ARGS=$(printf '%q ' "$@")

if [ -z "$*" ]; then
	show_usage
elif [ $1 == "su" ]; then
	CMDLINE="$CMDLINE;$BINPRE/bash"
elif [ -x "$BINPRE/$1" ]; then
	CMDLINE="$CMDLINE;$BINPRE/$ARGS"
elif [ -x $SYSBIN/$1 ] || [ -x $SYSXBIN/$1 ] || [ -x $1 ]; then
	CMDLINE="$CMDLINE;$ARGS"
else
	echo -e "\nCommand `color 1 $1` not found"
	echo -e "`color 2 Check your spelling and try again`\n"
fi

pre_env_chk=`$SU --help|grep -e --preserve-environment`

if [ -x "/sbin/magisk" ]; then
	unset LD_LIBRARY_PATH
fi

if [ -n "$pre_env_chk" ]; then
        $SU --preserve-environment -c "$CMDLINE"
else
        $SU -c "$CMDLINE"
fi

# Reset echo
stty sane